### PR TITLE
Bluesky run v2

### DIFF
--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
@@ -162,6 +162,10 @@ class ConfigDatasetClient(DictView):
         return tiled_repr.replace(type(self).__name__, "DatasetClient")
 
     def read(self):
+        # Delay this import for fast startup. In some cases only metadata
+        # is handled, and we can avoid the xarray import altogether.
+        import xarray
+
         d = {k: {"dims": "time", "data": v.read()} for k, v in self._internal_dict.items()}
         return xarray.Dataset.from_dict(d)
 
@@ -194,6 +198,10 @@ class VirtualContainer(DictView):
 
 class VirtualArrayClient:
     def __init__(self, data, dims=None):
+        # Delay this import for fast startup. In some cases only metadata
+        # is handled, and we can avoid the numpy import altogether.
+        import numpy
+
         # Ensure data is an array-like object
         if not hasattr(data, "__iter__") or isinstance(data, str):
             data = [data]

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_event_stream.py
@@ -3,13 +3,13 @@ import warnings
 
 from tiled.client.container import DEFAULT_STRUCTURE_CLIENT_DISPATCH, Container
 from tiled.client.composite import Composite
-from tiled.client.utils import handle_error
 from tiled.utils import DictView, OneShotCachedMap, node_repr, Sentinel
 
 from ._common import IPYTHON_METHODS
 
 ONLY_DATA = Sentinel("ONLY_DATA")
 ONLY_TIMESTAMPS = Sentinel("ONLY_TIMESTAMPS")
+
 
 class BlueskyEventStream(Container):
     def __new__(cls, context, *, item, structure_clients, **kwargs):

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -142,6 +142,15 @@ class BlueskyRunV2(BlueskyRun):
         return _cls(context, item=item, structure_clients=structure_clients, **kwargs)
 
     @property
+    def v1(self):
+        "Accessor to legacy interface."
+        from databroker.v1 import Broker, Header
+
+        db = Broker(self)
+        header = Header(self, db)
+        return header
+
+    @property
     def v2(self):
         return self
 
@@ -257,6 +266,11 @@ class BlueskyRunV3(_BlueskyRunSQL):
             return self["streams"][key]
 
         return super().__getattr__(key)
+
+    @property
+    def v1(self):
+        "Access to legacy interface"
+        return self.v2.v1
 
     @property
     def v2(self):

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -6,8 +6,6 @@ import warnings
 from collections import defaultdict
 from datetime import datetime
 
-import numpy
-import xarray
 from event_model import StreamDatum, StreamResource
 from tiled.client.container import Container
 from tiled.client.utils import handle_error
@@ -266,3 +264,139 @@ class BlueskyRunV3(_BlueskyRunSQL):
     @property
     def v3(self):
         return self
+
+
+class VirtualContainer(DictView):
+    def __repr__(self):
+        tiled_repr = node_repr(self, self._internal_dict.keys())
+        return tiled_repr.replace(type(self).__name__, "ContainerClient")
+
+    def __getitem__(self, key):
+        if "/" in key:
+            key, rest = key.split("/", 1)
+            return self[key][rest]
+
+        return super().__getitem__(key)
+
+
+class ConfigDatasetClient(DictView):
+    def __repr__(self):
+        tiled_repr = node_repr(self, self._internal_dict.keys())
+        return tiled_repr.replace(type(self).__name__, "DatasetClient")
+
+    def read(self):
+        # Delay this import for fast startup. In some cases only metadata
+        # is handled, and we can avoid the xarray import altogether.
+        import xarray
+
+        d = {k: {"dims": "time", "data": v.read()} for k, v in self._internal_dict.items()}
+        return xarray.Dataset.from_dict(d)
+
+
+class CompositeDatasetClient(DictView):
+    def __init__(self, node, keys):
+        super().__init__({k: lambda _k=k: node[_k] for k in sorted(set(keys))})
+        self._node = node
+
+    def __repr__(self):
+        tiled_repr = node_repr(self, self._internal_dict.keys())
+        return tiled_repr.replace(type(self).__name__, "DatasetClient")
+
+    def read(self):
+        return self._node.read(variables=list(self.keys()))
+
+
+class VirtualArrayClient:
+    def __init__(self, data, dims=None):
+        # Ensure data is an array-like object
+        if not hasattr(data, "__iter__") or isinstance(data, str):
+            data = [data]
+        if not hasattr(data, "__array__"):
+            # Delay this import for fast startup. In some cases only metadata
+            # is handled, and we can avoid the numpy import altogether.
+            import numpy
+
+            data = numpy.asanyarray(data)
+
+        self._data = data
+        self._dims = dims
+
+    def __getitem__(self, slice):
+        return self.read(slice)
+
+    def __repr__(self):
+        attrs = {"shape": self.shape, "dtype": self.dtype}
+        if dims := self.dims:
+            attrs["dims"] = dims
+        return "<ArrayClient" + "".join(f" {k}={v}" for k, v in attrs.items()) + ">"
+
+    def read(self, slice=None):
+        return self._data if slice is None else self._data[slice]
+
+    @property
+    def size(self):
+        return self._data.size
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def dims(self):
+        return self._dims
+
+
+class BlueskyStreamView(OneShotCachedMap):
+    def __init__(self, internal_dict, metadata=None):
+        super().__init__(internal_dict)
+        self.metadata = metadata or {}
+
+    def __repr__(self):
+        stream_name = self.metadata.get("stream_name")
+        return f"<BlueskyEventStream {set(self)!r} stream_name={stream_name!r}>"
+
+    def __getitem__(self, key):
+        if "/" in key:
+            key, rest = key.split("/", 1)
+            return self[key][rest]
+
+        return super().__getitem__(key)
+
+    @staticmethod
+    def format_config(config_client, timestamp=False):
+        records = config_client.read().to_list()
+        values = defaultdict(dict)
+        for rec in records:
+            if (rec.get("object_name") is not None) and (rec.get("value") is not None):
+                values[rec["object_name"]][rec["data_key"]] = (
+                    VirtualArrayClient(rec["timestamp"]) if timestamp else VirtualArrayClient(rec["value"])
+                )
+        result = {k: ConfigDatasetClient(v) for k, v in values.items()}
+        return VirtualContainer(result)
+
+    @classmethod
+    def from_container_and_config(cls, stream_client, config_client):
+        stream_parts = set(stream_client.parts)
+        data_keys = [k for k in stream_parts if k != "internal"]
+        ts_keys = ["time"]
+        if "internal" in stream_parts:
+            internal_cols = stream_client.parts["internal"].columns
+            data_keys += [col for col in internal_cols if col != "seq_num" and not col.startswith("ts_")]
+            ts_keys += [col for col in internal_cols if col.startswith("ts_")]
+        internal_dict = {
+            # "data": lambda: stream_client.to_dataset(*sorted(set(data_keys))),
+            # "timestamps": lambda: stream_client.to_dataset(*ts_keys),
+            "data": lambda: CompositeDatasetClient(stream_client, data_keys),
+            "timestamps": lambda: CompositeDatasetClient(stream_client, ts_keys),
+            "config": lambda: cls.format_config(config_client),
+            "config_timestamps": lambda: cls.format_config(config_client, timestamp=True),
+        }
+
+        # Construct the metadata
+        metadata = {"descriptors": [], "stream_name": stream_client.item["id"], **stream_client.metadata}
+
+        return cls(internal_dict, metadata=metadata)

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/bluesky_run.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import io
 import json
@@ -146,8 +147,9 @@ class BlueskyRunV2(BlueskyRun):
 
     @property
     def v3(self):
-        self.structure_clients.set("BlueskyRun", lambda: BlueskyRunV3)
-        return BlueskyRunV3(self.context, item=self.item, structure_clients=self.structure_clients)
+        structure_clients = copy.copy(self.structure_clients)
+        structure_clients.set("BlueskyRun", lambda: BlueskyRunV3)
+        return BlueskyRunV3(self.context, item=self.item, structure_clients=structure_clients)
 
 
 class BlueskyRunV2Mongo(BlueskyRunV2):
@@ -258,8 +260,9 @@ class BlueskyRunV3(_BlueskyRunSQL):
 
     @property
     def v2(self):
-        self.structure_clients.set("BlueskyRun", lambda: BlueskyRunV2)
-        return BlueskyRunV2(self.context, item=self.item, structure_clients=self.structure_clients)
+        structure_clients = copy.copy(self.structure_clients)
+        structure_clients.set("BlueskyRun", lambda: BlueskyRunV2)
+        return BlueskyRunV2(self.context, item=self.item, structure_clients=structure_clients)
 
     @property
     def v3(self):

--- a/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
+++ b/bluesky-tiled-plugins/bluesky_tiled_plugins/catalog_of_bluesky_runs.py
@@ -1,4 +1,5 @@
 import collections.abc
+import copy
 import numbers
 import operator
 
@@ -7,7 +8,7 @@ from tiled.client.container import Container
 from tiled.client.utils import handle_error
 from tiled.utils import safe_json_dump
 
-from .bluesky_run import BlueskyRun, BlueskyRunV2
+from .bluesky_run import BlueskyRunV2
 from .queries import PartialUID, RawMongo, ScanID
 
 
@@ -66,12 +67,12 @@ class CatalogOfBlueskyRuns(Container):
 
     @property
     def v2(self):
-        self.structure_clients.set("BlueskyRun", lambda: BlueskyRunV2)
-        return CatalogOfBlueskyRuns(self.context, item=self.item, structure_clients=self.structure_clients)
+        structure_clients = copy.copy(self.structure_clients)
+        structure_clients.set("BlueskyRun", lambda: BlueskyRunV2)
+        return CatalogOfBlueskyRuns(self.context, item=self.item, structure_clients=structure_clients)
 
     @property
     def v3(self):
-        self.structure_clients.set("BlueskyRun", lambda: BlueskyRun)
         return self
 
     def __getitem__(self, key):


### PR DESCRIPTION
See commit messages for details. The `v1` accessor does not quite work yet, may require additional changes.

```py
from tiled.client import from_uri
from bluesky import RunEngine
from ophyd.sim import det, motor, img
from bluesky.plans import scan, count
from bluesky.callbacks.tiled_writer import TiledWriter

client = from_uri('http://localhost:8000', api_key='secret')
tw = TiledWriter(client)
RE = RunEngine()
RE.subscribe(tw)
RE(count([det]))

run = client.values().last()
run.v1.table()
```